### PR TITLE
feat: useTooltipPosition 훅 적용 및 Tooltip 포지션 동적 제어 기능 추가

### DIFF
--- a/src/components/common/Tooltip.jsx
+++ b/src/components/common/Tooltip.jsx
@@ -1,43 +1,30 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
-function Tooltip({ children, visible }) {
-  const tooltipStyle = `
-    .custom-tooltip {
-      position: absolute;
-      right: 0;
-      width: 320px;
-      background-color: #1a1f36;
-      color: white;
-      padding: 20px;
-      border-radius: 8px;
-      z-index: 10;
-      box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
-      line-height: 1.7;
-    }
-    
-    .custom-tooltip p {
-      margin-bottom: 5px;
-      font-size: 16px;
-    }
-    
-    .custom-tooltip p:last-child {
-      margin-bottom: 0;
-    }
-    
-    .custom-tooltip strong {
-      font-weight: 600;
-    }
-  `;
-  
-  if (!visible) return null;
-  
-  return (
-    <>
-      <style>{tooltipStyle}</style>
-      <div className="custom-tooltip">
-        {children}
-      </div>
-    </>
+function Tooltip({ children, visible, position }) {
+  if (!visible || !position) return null;
+
+  const { top, left } = position;
+
+  const tooltipStyle = {
+    position: 'fixed',
+    top,
+    left,
+    width: '320px',
+    backgroundColor: '#1a1f36',
+    color: 'white',
+    padding: '20px',
+    borderRadius: '8px',
+    zIndex: 9999,
+    boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.3)',
+    lineHeight: 1.7,
+  };
+
+  return ReactDOM.createPortal(
+    <div style={tooltipStyle}>
+      {children}
+    </div>,
+    document.body
   );
 }
 

--- a/src/components/indicators/FearGreedIndex.jsx
+++ b/src/components/indicators/FearGreedIndex.jsx
@@ -1,9 +1,10 @@
 // src/components/indicators/FearGreedIndex.jsx
-import React, { useState } from 'react';
+import React from 'react';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function FearGreedIndex({ value }) {
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
   
   const getStatusText = () => {
     if (value === null) return '로딩 중';
@@ -32,13 +33,13 @@ function FearGreedIndex({ value }) {
             className="h-5 w-5 text-white opacity-50 cursor-pointer hover:opacity-100" 
             viewBox="0 0 20 20" 
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
           </svg>
 
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             <p><strong>0~24:</strong> 극단적 공포</p>
             <p><strong>25~39:</strong> 공포</p>
             <p><strong>40~60:</strong> 중립</p>

--- a/src/components/indicators/KimchiPremium.jsx
+++ b/src/components/indicators/KimchiPremium.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import dashboardApi from '../../api/dashboardApi';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function KimchiPremium() {
   const [premiumData, setPremiumData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
   
   useEffect(() => {
     const fetchKimchiPremium = async () => {
@@ -56,13 +57,13 @@ function KimchiPremium() {
             className="h-5 w-5 text-white opacity-50 cursor-pointer hover:opacity-100" 
             viewBox="0 0 20 20" 
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
           </svg>
           
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             <p className="mb-3"><strong>국내 거래소:</strong> 업비트 / <strong>해외 거래소:</strong> 바이낸스</p>
             <p className="leading-relaxed">국내 거래소에서 코인이 해외 거래소보다 비싸게 거래되는 현상</p>
           </Tooltip>

--- a/src/components/indicators/LongShortRatio.jsx
+++ b/src/components/indicators/LongShortRatio.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function LongShortRatio({ longRatio, shortRatio }) {
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
 
   const formatRatio = (val) => `${Number(val).toFixed(2)}%`;
 
@@ -17,8 +18,8 @@ function LongShortRatio({ longRatio, shortRatio }) {
             className="h-5 w-5 text-white opacity-50 cursor-pointer hover:opacity-100"
             viewBox="0 0 20 20"
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path
               fillRule="evenodd"
@@ -26,7 +27,7 @@ function LongShortRatio({ longRatio, shortRatio }) {
               clipRule="evenodd"
             />
           </svg>
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             <p className="mb-3">바이낸스 선물 비트코인 롱/숏 포지션 비율</p>
             <p className="mb-3"><strong>롱 포지션:</strong> 상승을 예상한 매수 포지션</p>
             <p className="leading-relaxed"><strong>숏 포지션:</strong> 하락을 예상한 매도 포지션</p>

--- a/src/components/indicators/MacdIndicator.jsx
+++ b/src/components/indicators/MacdIndicator.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function MacdIndicator({ macd, signal, histogram }) {
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
 
   const formatNumber = (value) => {
     return Number(value).toFixed(2);
@@ -22,13 +23,13 @@ function MacdIndicator({ macd, signal, histogram }) {
             className="h-5 w-5 text-white opacity-50 cursor-pointer hover:opacity-100" 
             viewBox="0 0 20 20" 
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
           </svg>
           
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             <p className="mb-3"><strong>MACD:</strong> 단기 이동선, 장기 이동선 차이</p>
             <p className="mb-3">음수면 하락세, 양수면 상승세</p>
             <p className="mb-3"><strong>Signal:</strong> 매매 시점 판단 기준</p>

--- a/src/components/indicators/RsiIndicator.jsx
+++ b/src/components/indicators/RsiIndicator.jsx
@@ -1,9 +1,10 @@
 // src/components/indicators/RsiIndicator.jsx
-import React, { useState } from 'react';
+import React from 'react';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function RsiIndicator({ value }) {
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
   
   const formatRsiValue = (val) => {
     return Number(val).toFixed(1);
@@ -33,13 +34,13 @@ function RsiIndicator({ value }) {
             className="h-5 w-5 text-white opacity-50 cursor-pointer hover:opacity-100" 
             viewBox="0 0 20 20" 
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
           </svg>
           
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             <p className="mb-3"><strong>30↓:</strong> 과매도, <strong>70↑:</strong> 과매수</p>
             <p className="leading-relaxed">최근 가격 변동 중 상승과 하락의 상대적 강도를 비교하여 과매수/과매도 상태 판단</p>
           </Tooltip>

--- a/src/components/transactions/TransactionList.jsx
+++ b/src/components/transactions/TransactionList.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef, useId } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Tooltip from '../common/Tooltip';
+import useTooltipPosition from '../../hooks/useTooltipPosition';
 
 function TransactionList({ title, symbol = 'BTC', isWhale = false }) {
   const [transactions, setTransactions] = useState([]);
-  const [showTooltip, setShowTooltip] = useState(false);
+  const { visible, position, onMouseEnter, onMouseLeave } = useTooltipPosition();
   const scrollRef = useRef(null);
   const componentId = useId();
 
@@ -118,13 +119,13 @@ function TransactionList({ title, symbol = 'BTC', isWhale = false }) {
             className="h-6 w-6 text-white opacity-50 cursor-pointer hover:opacity-100" 
             viewBox="0 0 20 20" 
             fill="currentColor"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
           </svg>
           
-          <Tooltip visible={showTooltip}>
+          <Tooltip visible={visible} position={position}>
             {isWhale ? (
               <p className="leading-relaxed">1,000만원 이상의 {symbol} 거래를 실시간으로 표시합니다.</p>
             ) : (

--- a/src/hooks/useTooltipPosition.js
+++ b/src/hooks/useTooltipPosition.js
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+function useTooltipPosition(offset = { x: -320, y: 25 }) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState(null);
+
+  const onMouseEnter = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setPosition({
+      top: rect.top + offset.y,
+      left: rect.right + offset.x,
+    });
+    setVisible(true);
+  };
+
+  const onMouseLeave = () => {
+    setVisible(false);
+    setPosition(null);
+  };
+
+  return {
+    visible,
+    position,
+    onMouseEnter,
+    onMouseLeave,
+  };
+}
+
+export default useTooltipPosition;


### PR DESCRIPTION
- Tooltip 컴포넌트를 React Portal 방식으로 수정하여 z-index 문제 해결
- 공포탐욕지수, RSI, MACD, 김치프리미엄, 공매수/공매도, 고래 체결 내역 등 주요 지표 컴포넌트에 useTooltipPosition 훅을 적용해 툴팁 위치 동적 계산
- Sidebar 등 다른 요소에 툴팁이 가려지는 문제 해결
- Close #83 